### PR TITLE
Fix compare links after action in ranking

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/compare.js
+++ b/app/assets/javascripts/gobierto_budgets/compare.js
@@ -137,7 +137,7 @@ $(function () {
       Cookies.set('comparison',comparison);
   }
 
-  $('.js-add_compare, .js-add_compare_no_hide').on('click', function(e) {
+  $(document).on('click', '.js-add_compare, .js-add_compare_no_hide', function(e) {
     e.preventDefault();
     updateListAndCompare($(this).data('place'), $(this).data('parent-code'));
   });


### PR DESCRIPTION
This PR fixes compare link on rankings page after a filter is applied.

Closes https://github.com/PopulateTools/gobierto-budgets-comparator-gen-cat/issues/69