### PR TITLE
Support redirect with or without year

### DIFF
--- a/app/controllers/gobierto_budgets/places_controller.rb
+++ b/app/controllers/gobierto_budgets/places_controller.rb
@@ -105,8 +105,9 @@ module GobiertoBudgets
 
     def redirect
       @place = INE::Places::Place.find params[:ine_code]
+      year = params[:year] || GobiertoBudgets::SearchEngineConfiguration::Year.last
       if @place.present?
-        redirect_to gobierto_budgets_place_path(@place.slug, GobiertoBudgets::SearchEngineConfiguration::Year.last)
+        redirect_to gobierto_budgets_place_path(@place.slug, year)
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,7 @@ Rails.application.routes.draw do
     get '/budget_lines/:slug/:year/:code/:kind/:area' => 'budget_lines#show', as: :budget_line
     get '/budget_lines/:slug/:year/:code/:kind/:area/feedback/:question_id' => 'budget_lines#feedback', as: :budget_line_feedback
     get '/places/:slug' => 'places#show'
-    get '/places/:ine_code/redirect' => 'places#redirect'
+    get '/places/:ine_code(/:year)/redirect' => 'places#redirect'
     get '/places/:slug/inteligencia' => 'places#intelligence'
     get '/places/:slug/:year/execution' => 'places#execution', as: :place_execution
     get '/places/:slug/:year/debt' => 'places#debt_alive'


### PR DESCRIPTION
So we fix the links in the maps. To ensure we don't break the existing URLs for the regular comparator nor the gencat one.

Links to a regular place, using slug:

* http://gencat-presupuestos.gobify.net/places/barcelona/2016
* http://presupuestos.gobify.net/places/alfambra/2018

Links to an associated entity (with and without year):

* http://gencat-presupuestos.gobify.net/places/barcelona/institut-municipal-d-informatica-de-barcelona/2016
* http://gencat-presupuestos.gobify.net/places/barcelona/institut-municipal-d-informatica-de-barcelona

The map links:

* http://presupuestos.gobify.net/mapas/2018
* http://gencat-presupuestos.gobify.net/mapas/2018

Redirects:

* http://gencat-presupuestos.gobify.net/places/25042/2015/redirect
* http://gencat-presupuestos.gobify.net/places/25042/redirect
* http://presupuestos.gobify.net/places/25042/2015/redirect
* http://presupuestos.gobify.net/places/25042/redirect

**Notes**

* Please also take a look at the [conflicts resolution](https://github.com/PopulateTools/gobierto-comparador-presupuestos/commit/c48df21299a85b611708472d6438fd94b7a7cde2) in staging.
* When this is merged we also need to update the master branch of the gencat comparator