### PR TITLE
Speedup rankings

### DIFF
--- a/app/controllers/gobierto_budgets/places_controller.rb
+++ b/app/controllers/gobierto_budgets/places_controller.rb
@@ -104,14 +104,15 @@ module GobiertoBudgets
       @places = get_places params[:slug_list]
       redirect_to gobierto_budgets_compare_path if @places.empty?
 
-      @totals = GobiertoBudgets::BudgetTotal.for @places.map(&:id), @year
-      @population = GobiertoBudgets::Population.for @places.map(&:id), @year
+      ids = @places.map(&:id)
+      @totals = GobiertoBudgets::BudgetTotal.for ids, @year
+      @population = GobiertoBudgets::Population.for ids, @year
       if @population.empty?
-        @population = GobiertoBudgets::Population.for @places.map(&:id), @year - 1
+        @population = GobiertoBudgets::Population.for ids, @year - 1
       end
 
       @compared_level = (params[:parent_code].present? ? params[:parent_code].length + 1 : 1)
-      options = { ine_codes: @places.map(&:id), year: @year, kind: @kind, level: @compared_level, type: @area_name }
+      options = { ine_codes: ids, year: @year, kind: @kind, level: @compared_level, type: @area_name }
 
       if @compared_level > 1
         @budgets_and_ancestors = GobiertoBudgets::BudgetLine.compare_with_ancestors(options.merge(parent_code: params[:parent_code]))

--- a/app/models/gobierto_budgets/budget_line.rb
+++ b/app/models/gobierto_budgets/budget_line.rb
@@ -299,7 +299,13 @@ module GobiertoBudgets
       query.merge!(from: options[:offset]) if options[:offset].present?
       query.merge!(_source: false) if options[:to_rank]
 
-      GobiertoBudgets::SearchEngine.client.search index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, type: options[:area_name], body: query
+      GobiertoBudgets::SearchEngine.client.search(
+        index: GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast,
+        type: options[:area_name],
+        body: query,
+        filter_path: options[:to_rank] ? "hits.total" : "hits.hits._source,hits.total",
+        _source: ["population", "ine_code", "amount", "amount_per_inhabitant"]
+      )
     end
 
     def self.find(options)

--- a/app/models/gobierto_budgets/budget_total.rb
+++ b/app/models/gobierto_budgets/budget_total.rb
@@ -82,10 +82,12 @@ module GobiertoBudgets
       response = SearchEngine.client.search(
         index: SearchEngineConfiguration::TotalBudget.index_forecast,
         type: SearchEngineConfiguration::TotalBudget.type,
-        body: query
+        body: query,
+        filter_path: "hits.hits._source",
+        _source: ["total_budget", "ine_code", "total_budget_per_inhabitant"]
       )
 
-      return response['hits']['hits'].map{ |h| h['_source'] }
+      response['hits']['hits'].map{ |h| h['_source'] }
     end
 
     def self.for_ranking(year, variable, kind, offset, per_page, filters = {})
@@ -170,7 +172,11 @@ module GobiertoBudgets
         index = SearchEngineConfiguration::TotalBudget.index_executed
       end
 
-      SearchEngine.client.search index: index, type: SearchEngineConfiguration::TotalBudget.type, body: query
+      SearchEngine.client.search index: index,
+        type: SearchEngineConfiguration::TotalBudget.type,
+        body: query,
+        filter_path: "hits.hits._source",
+        _source: ["total_budget", "ine_code", "total_budget_per_inhabitant"]
     end
   end
 end

--- a/app/models/gobierto_budgets/population.rb
+++ b/app/models/gobierto_budgets/population.rb
@@ -102,7 +102,7 @@ module GobiertoBudgets
 
         budget_filters.merge!(aarr: aarr_filter) if aarr_filter
 
-        results,total_elements = BudgetTotal.for_ranking(options[:year], 'total_budget', GobiertoBudgets::BudgetLine::EXPENSE, 0, nil, budget_filters)
+        results, total_elements = BudgetTotal.for_ranking(options[:year], 'total_budget', GobiertoBudgets::BudgetLine::EXPENSE, 0, nil, budget_filters)
         ine_codes = results.map{|p| p['ine_code']}
         append_ine_codes(terms, ine_codes)
       end
@@ -136,7 +136,9 @@ module GobiertoBudgets
       SearchEngine.client.search(
         index: SearchEngineConfiguration::Data.index,
         type: SearchEngineConfiguration::Data.type_population,
-        body: query
+        body: query,
+        filter_path: options[:to_rank] ? "hits.total" : "hits.hits._source,hits.total",
+        _source: ["value", "ine_code"]
       )
     end
 

--- a/app/models/gobierto_budgets/ranking.rb
+++ b/app/models/gobierto_budgets/ranking.rb
@@ -44,6 +44,7 @@ module GobiertoBudgets
 
       places_ids = results.map{|h| h['ine_code']}
       total_results = BudgetTotal.for_places(places_ids, options[:year])
+      total_results = Hash[total_results.map{ |i| [i["ine_code"], i["total_budget"]]}]
 
       return results.map do |h|
         id = h['ine_code'].to_i
@@ -53,7 +54,7 @@ module GobiertoBudgets
           population: h['population'],
           amount_per_inhabitant: h['amount_per_inhabitant'],
           amount: h['amount'],
-          total: total_results.detect{|h| h['ine_code'] == id}['total_budget']
+          total: total_results[id]
         })
       end, total_elements
     end
@@ -63,15 +64,17 @@ module GobiertoBudgets
 
       places_ids = results.map{|h| h['ine_code']}
       total_results = BudgetTotal.for_places(places_ids, year)
+      total_results = Hash[total_results.map{ |i| [i["ine_code"], {total_budget: i["total_budget"], total_budget_per_inhabitant: i["total_budget_per_inhabitant"]}]}]
 
       return results.map do |h|
-        id = h['ine_code']
+        id = h['ine_code'].to_i
+
         Item.new({
           place: INE::Places::Place.find(id),
-          population: h['value'],
-          amount_per_inhabitant: total_results.detect{|h| h['ine_code'] == id}['total_budget_per_inhabitant'],
-          amount: total_results.detect{|h| h['ine_code'] == id}['total_budget'],
-          total: total_results.detect{|h| h['ine_code'] == id}['total_budget']
+          population: h["value"],
+          amount_per_inhabitant: total_results[id][:total_budget_per_inhabitant],
+          amount: total_results[id][:total_budget],
+          total: total_results[id][:total_budget]
         })
       end, total_elements
     end
@@ -89,12 +92,14 @@ module GobiertoBudgets
 
       places_ids = results.map {|h| h['ine_code']}
       population_results = Population.for_places(places_ids, year)
+      population_results = Hash[population_results.map{ |i| [i["ine_code"], i["value"]] }]
 
       return results.map do |h|
-        id = h['ine_code']
+        id = h['ine_code'].to_i
+
         Item.new({
           place: INE::Places::Place.find(id),
-          population: population_results.detect{|h| h['ine_code'] == id}.try(:[],'value'),
+          population: population_results[id],
           amount_per_inhabitant: h['total_budget_per_inhabitant'],
           amount: h['total_budget'],
           total: h['total_budget']

--- a/app/views/gobierto_budgets/places/_ranking_table.html.erb
+++ b/app/views/gobierto_budgets/places/_ranking_table.html.erb
@@ -33,7 +33,7 @@
 
     <tbody>
       <% @ranking_items.each_with_index do |ranking_item, i| %>
-        <tr <%= 'class="selected"'.html_safe if ranking_item.place == @place %> id='<%= "place_#{ranking_item.place.id}" %>'>
+        <tr <%= 'class="selected"'.html_safe if ranking_item.place == @place %> id='place_<%= ranking_item.place.id %>'>
           <td class="r_pos"><%= GobiertoBudgets::Ranking.position(i, @page) %>.</td>
           <td class="location"><%= link_to ranking_item.place.name, gobierto_budgets_place_path(ranking_item.place.slug, @year) %> (<%= ranking_item.place.province.name %>)</td>
           <td class="expense <%= class_if('selected', filter_selected?('population')) %>"><%= number_with_precision ranking_item.population, precision: 0, delimiter: '.' %></td>

--- a/app/views/gobierto_budgets/places/_year_switcher.html.erb
+++ b/app/views/gobierto_budgets/places/_year_switcher.html.erb
@@ -1,7 +1,7 @@
 <div class="switcher year_switcher">
     <%= link_to "#{@year} <i class='fa fa-angle-down'></i>".html_safe, '', class: 'current' %>
     <ul>
-      <% GobiertoBudgets::SearchEngineConfiguration::Year.last.downto(GobiertoBudgets::SearchEngineConfiguration::Year.first) do |y| %>
+      <% GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |y| %>
         <li><%= link_to y.to_s, url_for(params.reject {|k,v| k == 'page' }.merge(year: y)) %></li>
       <% end %>
     </ul>


### PR DESCRIPTION
This PR filters ES results fields to reduce the footprint of the response body. It also introduces some small optimization sin the code.

The improvement in staging is around 10% of speed and less CPU usage.

