### PR TITLE
Return 404 not found on invalid embeds

### DIFF
--- a/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
@@ -51,7 +51,7 @@ module GobiertoBudgets
       end
 
       respond_to do |format|
-        format.html { render(action: "embed", layout: "embed") }
+        format.html { @code.present? ? render(action: "embed", layout: "embed") : render_404 }
         format.js { @code.present? ? render(:show) : head(:not_found) }
       end
     end


### PR DESCRIPTION
This PR returns 404 when the budget line code parameter is invalid.

Fixes this noisy Rollbar: https://rollbar.com/Populate/gobierto-comparator/items/1771/?item_page=0&item_count=100&#instances