### PR TITLE
Activate 2020 data

### DIFF
--- a/app/models/gobierto_budgets/search_engine_configuration.rb
+++ b/app/models/gobierto_budgets/search_engine_configuration.rb
@@ -1,7 +1,7 @@
 module GobiertoBudgets
   class SearchEngineConfiguration
     class Year
-      def self.last; 2019 end
+      def self.last; 2020 end
       def self.first; 2010 end
       def self.all
         @all ||= (first..last).to_a.reverse


### PR DESCRIPTION
This PR activates 2020 data (following the process documented here: https://github.com/PopulateTools/gobierto/wiki/Updating-budgets-data)