### PR TITLE
Fix fallback calculation for population queries

### DIFF
--- a/app/controllers/gobierto_budgets/api/global_data_controller.rb
+++ b/app/controllers/gobierto_budgets/api/global_data_controller.rb
@@ -111,9 +111,13 @@ module GobiertoBudgets
 
       def total_budget_execution
         year = params[:year].to_i
-        year -= 1 if GobiertoBudgets::SearchEngineConfiguration::Year.fallback_year?(year)
         total_budget_data_planned = total_budget_data(year, 'total_budget')
         total_budget_data_executed = total_budget_data_executed(year, 'total_budget')
+        if total_budget_data_executed.nil? || total_budget_data_planned.nil?
+          year -= 1
+          total_budget_data_planned = total_budget_data(year, 'total_budget')
+          total_budget_data_executed = total_budget_data_executed(year, 'total_budget')
+        end
         diff = total_budget_data_executed - total_budget_data_planned rescue ""
         sign = sign(total_budget_data_executed, total_budget_data_planned)
         diff = format_currency(diff) if diff.is_a?(Float)

--- a/app/models/gobierto_budgets/search_engine_configuration.rb
+++ b/app/models/gobierto_budgets/search_engine_configuration.rb
@@ -6,9 +6,6 @@ module GobiertoBudgets
       def self.all
         @all ||= (first..last).to_a.reverse
       end
-      def self.fallback_year?(year)
-        self.last < Date.today.year ? year == self.last + 1 : year == self.last
-      end
     end
 
     class BudgetCategories


### PR DESCRIPTION
Closes https://github.com/PopulateTools/issues/issues/1196

This PR fixes how the population query was doing fallback to the previous year when data is not available.

This has started to be an issue since the change of year, as we haven't imported population data yet from 2020.

Working smoothly in http://presupuestos.gobify.net/