### PR TITLE
Increase the maxZoom and set the version deck.gl to 8.4.0

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/maps.js
+++ b/app/assets/javascripts/gobierto_budgets/maps.js
@@ -97,7 +97,7 @@ $(document).on('turbolinks:load', function() {
       longitude: mapPropertiesLon,
       zoom: mapPropertiesZoom,
       minZoom: 5,
-      maxZoom: 8
+      maxZoom: 9
     };
 
     deckgl = new deck.Deck({
@@ -364,7 +364,7 @@ $(document).on('turbolinks:load', function() {
               latitude: +selectElement[0].lon,
               zoom: 9,
               minZoom: 5,
-              maxZoom: 9,
+              maxZoom: 10,
               transitionInterpolator: new deck.FlyToInterpolator(),
               transitionDuration: 1500
             }

--- a/app/views/gobierto_budgets/pages/map.html.erb
+++ b/app/views/gobierto_budgets/pages/map.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:header) do %>
   <meta name="turbolinks-visit-control" content="reload">
-  <script src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>
+  <script src="https://unpkg.com/deck.gl@8.4.0/dist.min.js"></script>
 <% end %>
 
 <%

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,5 +8,5 @@ users_enabled: false
 map_center_lat: 39.3
 map_center_lon: -5.6
 map_zoom_level: 6
-map_topojson: 'municipalities_topojson.json'
+map_topojson: '/municipalities_topojson.json'
 twitter_account: '@gobierto'


### PR DESCRIPTION
- Increase the `maxZoom` property by one point.
- Set the version for the `deck.gl` to `8.4.0` to avoid errors in the future. Until now we had the latest version `<script src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>`