### PR TITLE
1352 rename gobierto data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'aws-ses'
 gem 'cocoon'
 gem 'nokogiri', '~> 1.12'
 gem 'json', '~> 2.1'
-gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
+gem "gobierto_budgets_data", git: "https://github.com/PopulateTools/gobierto_budgets_data.git"
 gem "bootsnap"
 gem 'sprockets', '~> 3.7.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: 814933d614c7fe05ffac21e838d6cf8d0f9531d6
+  remote: https://github.com/PopulateTools/gobierto_budgets_data.git
+  revision: 17761ea394fdb07418ee89a751482da4c6ebdaaf
   specs:
-    gobierto_data (0.1.0)
+    gobierto_budgets_data (0.1.0)
       actionpack (>= 5.0.0.1)
       activesupport (>= 5.0.0)
       aws-sdk (~> 2.11, >= 2.11.45)
@@ -394,7 +394,7 @@ DEPENDENCIES
   elasticsearch-extensions
   email_spec
   flight-for-rails
-  gobierto_data!
+  gobierto_budgets_data!
   hashie
   i18n-js (>= 3.0.0.rc11)
   ine-places

--- a/Rakefile
+++ b/Rakefile
@@ -2,5 +2,5 @@ require File.expand_path("../config/application", __FILE__)
 
 Rails.application.load_tasks
 
-spec = Gem::Specification.find_by_name "gobierto_data"
+spec = Gem::Specification.find_by_name "gobierto_budgets_data"
 load "#{spec.gem_dir}/lib/tasks/data.rake"

--- a/lib/tasks/gobierto_budgets/missing-categories.rake
+++ b/lib/tasks/gobierto_budgets/missing-categories.rake
@@ -5,10 +5,10 @@ namespace :gobierto_budgets do
     desc "Check missing categories"
     task check: :environment do
       missing = []
-      ::GobiertoData::GobiertoBudgets::ALL_KINDS.each do |kind|
-        [::GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME, ::GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME].each do |area_name|
+      ::GobiertoBudgetsData::GobiertoBudgets::ALL_KINDS.each do |kind|
+        [::GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME, ::GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME].each do |area_name|
 
-          missing_names = ::GobiertoData::GobiertoBudgets::BudgetLine.all(
+          missing_names = ::GobiertoBudgetsData::GobiertoBudgets::BudgetLine.all(
             kind: kind,
             area_name: area_name
           ).select do |bl|


### PR DESCRIPTION
Related to PopulateTools/issues#1352

This PR replaces namespaces of `GobiertoData` with `GobiertoBudgetsData` and updates the gems dependency to point `gobierto_budgets_data` instead of `gobierto_data`