### PR TITLE
Enable lograge logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ gem 'elasticsearch-extensions'
 gem 'oj'
 gem 'hashie'
 
+# Log
+gem "lograge"
+
 group :development, :test do
   gem "byebug", platform: :mri
   gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,11 @@ GEM
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -298,6 +303,8 @@ GEM
     redcarpet (3.5.1)
     ref (2.0.0)
     regexp_parser (2.1.1)
+    request_store (1.5.0)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -420,6 +427,7 @@ DEPENDENCIES
   json (~> 2.1)
   kaminari (~> 1.0)
   launchy
+  lograge
   meta-tags
   nokogiri (~> 1.12)
   oj

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,10 +50,13 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  if ENV["ENABLE_LOG_RAGE"].present?
+    config.log_level = :info
+    config.lograge.enabled = true
+  else
+    config.log_tags = [ :request_id ]
+    config.log_level = :debug
+  end
 
   # Use a different cache store in production.
   config.cache_store = :mem_cache_store, "localhost"

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -46,10 +46,13 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
+  if ENV["ENABLE_LOG_RAGE"].present?
+    config.log_level = :info
+    config.lograge.enabled = true
+  else
+    config.log_tags = [:request_id]
+    config.log_level = :debug
+  end
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)


### PR DESCRIPTION
This PR enables LogRage logs when the environment variable `ENABLE_LOG_RAGE`  is set.

Logs look like this:

```
I, [2021-12-02T06:01:50.543346 #3061991]  INFO -- : method=GET path=/ranking format=html controller=GobiertoBudgets::PagesController action=ranking status=200 duration=49.50 view=40.98
I, [2021-12-02T06:01:50.773700 #3061991]  INFO -- : method=GET path=/api/data/widget/ranking/2021/G/functional/amount_per_inhabitant/336.json format=json controller=GobiertoBudgets::Api::DataController action=ranking status=200 duration=122.55 view=0.20
I, [2021-12-02T06:01:50.857505 #3061991]  INFO -- : method=GET path=/api/data/widget/ranking/2021/I/economic/amount/344.json format=json controller=GobiertoBudgets::Api::DataController action=ranking status=200 duration=77.19 view=0.09
I, [2021-12-02T06:01:50.916039 #3061991]  INFO -- : method=GET path=/api/data/widget/ranking/2021/G/functional/amount/162.json format=json controller=GobiertoBudgets::Api::DataController action=ranking status=200 duration=55.59 view=0.22
I, [2021-12-02T06:01:50.937404 #3061991]  INFO -- : method=GET path=/api/data/widget/ranking/2021/G/functional/amount_per_inhabitant/165.json format=json controller=GobiertoBudgets::Api::DataController action=ranking status=200 duration=16.19 view=0.10
I, [2021-12-02T06:01:50.981135 #3061991]  INFO -- : method=GET path=/api/data/widget/ranking/2021/G/functional/amount/342.json format=json controller=GobiertoBudgets::Api::DataController action=ranking status=200 duration=41.04 view=0.18
I, [2021-12-02T06:01:51.024235 #3061991]  INFO -- : method=GET path=/api/data/widget/ranking/2021/G/functional/amount_per_inhabitant/44.json format=json controller=GobiertoBudgets::Api::DataController action=ranking status=200 duration=39.25 view=4.09
I, [2021-12-02T06:01:51.088117 #3061991]  INFO -- : method=GET path=/api/data/widget/ranking/2021/G/functional/amount_per_inhabitant/171.json format=json controller=GobiertoBudgets::Api::DataController action=ranking status=200 duration=46.75 view=0.16
I, [2021-12-02T06:01:51.330915 #3062011]  INFO -- : method=GET path=/api/data/widget/ranking/2021/I/economic/amount/313.json format=json controller=GobiertoBudgets::Api::DataController action=ranking status=200 duration=316.00 view=0.31

```