### PR TITLE
Add link to contratos.gobierto.es

### DIFF
--- a/app/helpers/gobierto_helper.rb
+++ b/app/helpers/gobierto_helper.rb
@@ -1,5 +1,17 @@
 module GobiertoHelper
 
+  def gobierto_contratos_place_url
+    if @current_organization.present?
+      if current_organization.place.present?
+        if current_organization.place.provice.autonomous_region.slug == "catalunya"
+          "https://contratos.gobierto.es/adjudicadores/ajuntament-de-#{current_organization.place.slug}"
+        else
+          "https://contratos.gobierto.es/adjudicadores/ayuntamiento-de-#{current_organization.place.slug}"
+        end
+      end
+    end
+  end
+
   def flush_the_flash(entity = nil)
     if flash[:notice]
       css_class = 'notice success'

--- a/app/views/layouts/gobierto_budgets_application.html.erb
+++ b/app/views/layouts/gobierto_budgets_application.html.erb
@@ -117,6 +117,9 @@
 <footer>
   <div class="gobierto_ref">
     <p><%= link_to image_tag('GobiertoFooter@2x.png', size: '401x18'), 'https://' + Settings.gobierto_host, target: 'blank' %></p>
+    <% if gobierto_contratos_place_url.present? %>
+      <p><%= link_to "Consulta los contratos de Ayuntamiento de #{current_organization.place.name}", gobierto_contratos_place_url, target: "blank" %></p>
+    <% end %>
     <p>Conoce otros productos en <a href="https://gobierto.es">gobierto.es</a></p>
   </div>
 

--- a/app/views/layouts/gobierto_budgets_application.html.erb
+++ b/app/views/layouts/gobierto_budgets_application.html.erb
@@ -118,9 +118,9 @@
   <div class="gobierto_ref">
     <p><%= link_to image_tag('GobiertoFooter@2x.png', size: '401x18'), 'https://' + Settings.gobierto_host, target: 'blank' %></p>
     <% if gobierto_contratos_place_url.present? %>
-      <p><%= link_to "Consulta los contratos de Ayuntamiento de #{current_organization.place.name}", gobierto_contratos_place_url, target: "blank" %></p>
+      <p>Consulta los <%= link_to "contratos del Ayuntamiento de #{current_organization.place.name}", gobierto_contratos_place_url, target: "blank" %></p>
     <% end %>
-    <p>Conoce otros productos en <a href="https://gobierto.es">gobierto.es</a></p>
+    <p><a href="https://gobierto.es">gobierto.es</a>: experiencia ciudadana, buen gobierno, y contratación.</p>
   </div>
 
   <menu>


### PR DESCRIPTION
Closes https://github.com/PopulateTools/gobierto-contratos/issues/3380

This PR adds a link to contratos.gobierto.es associated entity. The link is available in the footer, but can be moved elsewhere:

http://presupuestos.gobify.net/places/santander (gobierto / staging123)

<img width="567" alt="Screenshot 2023-09-09 at 07 56 20" src="https://github.com/PopulateTools/gobierto-comparador-presupuestos/assets/17616/dc696660-cce5-4065-b01e-22c8150e709a">
