### PR TITLE
Force quotes in dumping budgets CSV

### DIFF
--- a/lib/tasks/gobierto_budgets/carto_csv.rake
+++ b/lib/tasks/gobierto_budgets/carto_csv.rake
@@ -16,16 +16,16 @@ namespace :gobierto_budgets do
 
     desc 'Export planned budgets CSVs'
     task export_planned_budgets: :environment do
-      CSV.open("planned_budgets.csv", "wb") do |csv|
+      CSV.open("planned_budgets.csv", "wb", force_quotes: true) do |csv|
         csv << ['year', 'place_id', 'area', 'kind', 'amount', 'code', 'amount_per_inhabitant']
         GobiertoBudgets::SearchEngineConfiguration::Year.all.each do |year|
           puts year
           INE::Places::Place.all.each do |place|
             get_budgets(place, year, 'economic').each do |budget_line|
-              csv << [year, budget_line['ine_code'], 'e', budget_line['kind'], budget_line['amount'], budget_line['code'], budget_line['amount_per_inhabitant']]
+              csv << [year, budget_line['ine_code'], 'e', budget_line['kind'], budget_line['amount'], budget_line['code'].to_s, budget_line['amount_per_inhabitant']]
             end
             get_budgets(place, year, 'functional').each do |budget_line|
-              csv << [year, budget_line['ine_code'], 'f', budget_line['kind'], budget_line['amount'], budget_line['code'], budget_line['amount_per_inhabitant']]
+              csv << [year, budget_line['ine_code'], 'f', budget_line['kind'], budget_line['amount'], budget_line['code'].to_s, budget_line['amount_per_inhabitant']]
             end
           end
         end


### PR DESCRIPTION
This PR adds the force quotes option to the CSV dump used to load data in maps and data repositories.

Quotes are necessary because codes are strings not numbers, and without them the codes '01' and '011' are encoded as '1' and '11' which is not correct.