### PR TITLE
Add deputation data import

### DIFF
--- a/app/decorators/place_decorator.rb
+++ b/app/decorators/place_decorator.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+PLACES_COLLECTIONS = {
+  ine: INE::Places::Place.all,
+  deputation_eu: [
+    OpenStruct.new(id: "48000DD000", province_id: 48, autonomous_region_id: 16, name: "Diputación Foral de Vizcaya", custom_place_id: "deputation_eu"),
+    OpenStruct.new(id: "01000DD000", province_id: 1, autonomous_region_id: 16, name: "Diputación Foral de Alava", custom_place_id: "deputation_eu"),
+    OpenStruct.new(id: "20000DD000", province_id: 20, autonomous_region_id: 16, name: "Diputación Foral de Guipúzcoa", custom_place_id: "deputation_eu")
+  ]
+}
+
+class PlaceDecorator
+  attr_reader :id, :place
+  delegate :name, to: :place
+
+  def self.collection(key)
+    key = key.to_sym
+    raise "Invalid place_type #{key}. Valid place types: #{PLACES_COLLECTIONS.keys.join(", ")} " unless PLACES_COLLECTIONS.keys.include?(key)
+
+    PLACES_COLLECTIONS[key].map do |place|
+      new(place)
+    end
+  end
+
+  def initialize(place)
+    @place = place
+    @id = place.id
+  end
+
+  def attributes
+    @attributes ||= {
+      "place_id" => numeric_id? ? id.to_i : nil,
+      "province_id" => (place.try(:province_id) || place.province.id)&.to_i,
+      "autonomous_region_id" => (place.try(:autonomous_region_id) || place.province.autonomous_region.id)&.to_i
+    }
+  end
+
+  def custom_place_id
+    place.try(:custom_place_id)
+  end
+
+  def code
+    return id unless numeric_id?
+
+    "#{format("%.5i", id)}AA000"
+  end
+
+  def numeric_id?
+    id.is_a?(Numeric) || /\A\d+\z/.match?(id.to_s.strip)
+  end
+
+  def population?
+    attributes["place_id"].present?
+  end
+end

--- a/lib/tasks/gobierto_budgets/budgets-import.rake
+++ b/lib/tasks/gobierto_budgets/budgets-import.rake
@@ -168,7 +168,7 @@ SQL
           data = base_data.merge({
             amount: row['amount'].to_f.round(2), code: code,
             functional_code: functional_code, kind: 'G',
-            amount_per_inhabitant: (row['amount'].to_f / pop).round(2)
+            amount_per_inhabitant:  pop.presence && (row['amount'].to_f / pop).round(2)
           })
 
           id = [place.id,destination_year,"#{code}-#{functional_code}",'G'].join("/")
@@ -241,7 +241,7 @@ SQL
           data = base_data.merge({
             amount: row['amount'].to_f.round(2), code: code,
             level: level, kind: row['kind'],
-            amount_per_inhabitant: (row['amount'].to_f / pop).round(2),
+            amount_per_inhabitant:  pop.presence && (row['amount'].to_f / pop).round(2),
             parent_code: parent_code
           })
 

--- a/lib/tasks/gobierto_budgets/budgets-import.rake
+++ b/lib/tasks/gobierto_budgets/budgets-import.rake
@@ -306,7 +306,7 @@ SQL
     end
 
     desc "Import budgets from database into ElasticSearch. Example bin/rails gobierto_budgets:budgets:import['budgets-dbname','budgets-execution','economic',2015] place_id=28079 province_id=3 autonomous_region_id=5"
-    task :import, [:db_name, :index, :type, :year, :destination_year] => :environment do |t, args|
+    task :import, [:db_name, :index, :type, :year, :destination_year, :place_type] => :environment do |t, args|
       db_name = args[:db_name]
       index = args[:index] if BUDGETS_INDEXES.include?(args[:index])
       raise "Invalid index #{args[:index]}" if index.blank?
@@ -323,7 +323,15 @@ SQL
         destination_year = year
       end
 
-      self.send("import_#{type}_budgets", db_name, index, year, destination_year)
+      opts = if (place_type = args[:place_type]&.to_sym).present?
+               raise "Invalid place_type #{place_type}. Valid place types: #{PLACES_SETS.keys.join(", ")} " unless PLACES_SETS.keys.include?(place_type)
+
+               { place_type: place_type }
+             else
+               {}
+             end
+
+      self.send("import_#{type}_budgets", db_name, index, year, destination_year, **opts)
     end
   end
 end

--- a/lib/tasks/gobierto_budgets/budgets-import.rake
+++ b/lib/tasks/gobierto_budgets/budgets-import.rake
@@ -3,6 +3,14 @@ namespace :gobierto_budgets do
     BUDGETS_INDEXES = [GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast, GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed,
                        GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_executed_series, GobiertoBudgets::SearchEngineConfiguration::BudgetLine.index_forecast_updated]
     BUDGETS_TYPES = ['economic', 'functional', 'custom']
+    PLACES_SETS = {
+      ine: INE::Places::Place.all,
+      deputation_eu: [
+        OpenStruct.new(id: "48000DD000", province_id: 48, autonomous_region_id: 16, name: "Diputación Foral de Vizcaya", custom_id: "deputation_eu"),
+        OpenStruct.new(id: "01000DD000", province_id: 1, autonomous_region_id: 16, name: "Diputación Foral de Alava", custom_id: "deputation_eu"),
+        OpenStruct.new(id: "20000DD000", province_id: 20, autonomous_region_id: 16, name: "Diputación Foral de Guipúzcoa", custom_id: "deputation_eu")
+      ]
+    }
 
     def create_budgets_mapping(index, type)
       m = GobiertoBudgets::SearchEngine.client.indices.get_mapping index: index, type: type
@@ -77,37 +85,45 @@ namespace :gobierto_budgets do
       nil
     end
 
-    def import_functional_budgets(db_name, index, year, destination_year)
+    def import_functional_budgets(db_name, index, year, destination_year, opts = {})
       db = create_db_connection(db_name)
 
-      INE::Places::Place.all.each do |place|
-        if ENV['place_id'].present?
-          next if place.id.to_i != ENV['place_id'].to_i
-        end
-        if ENV['province_id'].present?
-          next if place.province.id.to_i != ENV['province_id'].to_i
-        end
-        if ENV['autonomous_region_id'].present?
-          next if place.province.autonomous_region.id.to_i != ENV['autonomous_region_id'].to_i
+      places_key = opts.fetch(:place_type, :ine)
+      places = PLACES_SETS[places_key]
+
+      places.each do |place|
+        place_attrs = place_attributes(place)
+
+        place_attrs.each do |key, value|
+          next if ENV[key].present? && value != ENV[key].to_i
         end
 
-        pop = population(place.id, destination_year) || population(place.id, destination_year - 1) || population(place.id, destination_year - 2)
+        next if ENV["custom_place_id"].present? && place.try(:custom_place_id) != ENV["custom_place_id"]
 
-        if pop.nil?
+        pop = if place_attrs["place_id"].present?
+                population(place.id, destination_year) || population(place.id, destination_year - 1) || population(place.id, destination_year - 2)
+              else
+                nil
+              end
+
+        if place_attrs["place_id"].present? && pop.nil?
           puts "- Skipping #{place.id} #{place.name} because population data is missing for #{destination_year} and #{destination_year-1}"
           next
         end
 
         base_data = {
-          ine_code: place.id.to_i, province_id: place.province.id.to_i, organization_id: place.id.to_s,
-          autonomy_id: place.province.autonomous_region.id.to_i, year: destination_year,
+          ine_code: place_attrs["place_id"],
+          province_id: place_attrs["province_id"],
+          autonomy_id: place_attrs["autonomous_region_id"],
+          organization_id: place.id.to_s,
+          year: destination_year,
           population: pop
         }
 
         sql = <<-SQL
 SELECT tb_funcional_#{year}.cdfgr as code, sum(tb_funcional_#{year}.importe) as amount
 FROM tb_funcional_#{year}
-INNER JOIN "tb_inventario_#{year}" ON tb_inventario_#{year}.idente = tb_funcional_#{year}.idente AND tb_inventario_#{year}.codente = '#{format("%.5i", place.id)}AA000'
+INNER JOIN "tb_inventario_#{year}" ON tb_inventario_#{year}.idente = tb_funcional_#{year}.idente AND tb_inventario_#{year}.codente = '#{place_code(place)}'
 GROUP BY tb_funcional_#{year}.cdfgr
 SQL
 
@@ -124,7 +140,7 @@ SQL
           data = base_data.merge({
             amount: row['amount'].to_f.round(2), code: code,
             level: level, kind: 'G',
-            amount_per_inhabitant: (row['amount'].to_f / pop).round(2),
+            amount_per_inhabitant: pop.presence && (row['amount'].to_f / pop).round(2),
             parent_code: parent_code
           })
 
@@ -139,7 +155,7 @@ SQL
         sql = <<-SQL
 SELECT tb_funcional_#{year}.cdcta as code, tb_funcional_#{year}.cdfgr as functional_code, tb_funcional_#{year}.importe as amount
 FROM tb_funcional_#{year}
-INNER JOIN "tb_inventario_#{year}" ON tb_inventario_#{year}.idente = tb_funcional_#{year}.idente AND tb_inventario_#{year}.codente = '#{format("%.5i", place.id)}AA000'
+INNER JOIN "tb_inventario_#{year}" ON tb_inventario_#{year}.idente = tb_funcional_#{year}.idente AND tb_inventario_#{year}.codente = '#{place_code(place)}'
 SQL
 
         index_request_body = []
@@ -164,29 +180,38 @@ SQL
       end
     end
 
-    def import_economic_budgets(db_name, index, year, destination_year)
+    def import_economic_budgets(db_name, index, year, destination_year, opts = {})
       db = create_db_connection(db_name)
 
-      INE::Places::Place.all.each do |place|
-        if ENV['place_id'].present?
-          next if place.id.to_i != ENV['place_id'].to_i
-        end
-        if ENV['province_id'].present?
-          next if place.province.id.to_i != ENV['province_id'].to_i
-        end
-        if ENV['autonomous_region_id'].present?
-          next if place.province.autonomous_region.id.to_i != ENV['autonomous_region_id'].to_i
+      places_key = opts.fetch(:place_type, :ine)
+      places = PLACES_SETS[places_key]
+
+      places.each do |place|
+        place_attrs = place_attributes(place)
+
+        place_attrs.each do |key, value|
+          next if ENV[key].present? && value != ENV[key].to_i
         end
 
-        pop = population(place.id, destination_year) || population(place.id, destination_year - 1) || population(place.id, destination_year - 2)
-        if pop.nil?
+        next if ENV["custom_place_id"].present? && place.try(:custom_place_id) != ENV["custom_place_id"]
+
+        pop = if place_attrs["place_id"].present?
+                population(place.id, destination_year) || population(place.id, destination_year - 1) || population(place.id, destination_year - 2)
+              else
+                nil
+              end
+
+        if place_attrs["place_id"].present? && pop.nil?
           puts "- Skipping #{place.id} #{place.name} because population data is missing for #{destination_year} and #{destination_year-1}"
           next
         end
 
         base_data = {
-          ine_code: place.id.to_i, province_id: place.province.id.to_i, organization_id: place.id.to_s,
-          autonomy_id: place.province.autonomous_region.id.to_i, year: destination_year,
+          ine_code: place_attrs["place_id"],
+          province_id: place_attrs["province_id"],
+          autonomy_id: place_attrs["autonomous_region_id"],
+          organization_id: place.id.to_s,
+          year: destination_year,
           population: pop
         }
 
@@ -199,7 +224,7 @@ SQL
         sql = <<-SQL
 SELECT tb_economica_#{year}.cdcta as code, tb_economica_#{year}.tipreig AS kind, tb_economica_#{year}.#{amount_column} as amount
 FROM tb_economica_#{year}
-INNER JOIN "tb_inventario_#{year}" ON tb_inventario_#{year}.idente = tb_economica_#{year}.idente AND tb_inventario_#{year}.codente = '#{format("%.5i", place.id)}AA000'
+INNER JOIN "tb_inventario_#{year}" ON tb_inventario_#{year}.idente = tb_economica_#{year}.idente AND tb_inventario_#{year}.codente = '#{place_code(place)}'
 SQL
 
         index_request_body = []
@@ -227,6 +252,24 @@ SQL
 
         GobiertoBudgets::SearchEngine.client.bulk index: index, type: 'economic', body: index_request_body
       end
+    end
+
+    def place_attributes(place)
+      {
+        "place_id" => numeric?(place.id) ? place.id.to_i : nil,
+        "province_id" => place.try(:province_id) || place.province.id.to_i,
+        "autonomous_region_id" => place.try(:autonomous_region_id) || place.province.autonomous_region.id.to_i
+      }
+    end
+
+    def place_code(place)
+      return place.id unless numeric?(place.id)
+
+      "#{format("%.5i", place.id)}AA000"
+    end
+
+    def numeric?(value)
+      value.is_a?(Numeric) || /\A\d+\z/.match?(value.to_s.strip)
     end
 
     desc 'Reset ElasticSearch'

--- a/lib/tasks/gobierto_budgets/total-budget-import.rake
+++ b/lib/tasks/gobierto_budgets/total-budget-import.rake
@@ -46,7 +46,7 @@ namespace :gobierto_budgets do
                   {term: { organization_id: place.id.to_s }},
                   {missing: { field: 'functional_code'}},
                   {missing: { field: 'custom_code'}}
-                ]
+                ].select { |condition| condition.values.all? { |val| val.values.all?(&:present?) } }
               }
             }
           }

--- a/lib/tasks/gobierto_budgets/total-budget-import.rake
+++ b/lib/tasks/gobierto_budgets/total-budget-import.rake
@@ -63,17 +63,16 @@ namespace :gobierto_budgets do
       return result['aggregations']['total_budget']['value'].round(2), result['aggregations']['total_budget_per_inhabitant']['value'].round(2)
     end
 
-    def import_total_budget(year, index, kind)
-      INE::Places::Place.all.each do |place|
-        if ENV['place_id'].present?
-          next if place.id.to_i != ENV['place_id'].to_i
+    def import_total_budget(year, index, kind, opts = {})
+      places_key = opts.fetch(:place_type, :ine)
+      places = PlaceDecorator.collection(places_key)
+
+      places.each do |place|
+        place.attributes.each do |key, value|
+          next if ENV[key].present? && value != ENV[key].to_i
         end
-        if ENV['province_id'].present?
-          next if place.province.id.to_i != ENV['province_id'].to_i
-        end
-        if ENV['autonomous_region_id'].present?
-          next if place.province.autonomous_region.id.to_i != ENV['autonomous_region_id'].to_i
-        end
+
+        next if ENV["custom_place_id"].present? && place.custom_place_id != ENV["custom_place_id"]
 
         total_budget, total_budget_per_inhabitant = get_data(index, place, year, kind)
         if total_budget == 0.0 && kind == 'G'
@@ -81,8 +80,11 @@ namespace :gobierto_budgets do
         end
 
         data = {
-          ine_code: place.id.to_i, province_id: place.province.id.to_i, organization_id: place.id.to_s,
-          autonomy_id: place.province.autonomous_region.id.to_i, year: year,
+          ine_code: place.attributes["place_id"],
+          province_id: place.attributes["province_id"],
+          autonomy_id: place.attributes["autonomous_region_id"],
+          organization_id: place.id.to_s,
+          year: year,
           kind: kind,
           total_budget: total_budget,
           total_budget_per_inhabitant: total_budget_per_inhabitant
@@ -121,7 +123,7 @@ namespace :gobierto_budgets do
     end
 
     desc "Import total budgets. Example rake total_budget:import['budgets-execution',2014] place_id=28079 province_id=3 autonomous_region_id=5"
-    task :import, [:index,:year] => :environment do |t, args|
+    task :import, [:index, :year, :place_type] => :environment do |t, args|
       index = args[:index] if TOTAL_BUDGET_INDEXES.include?(args[:index])
       raise "Invalid index #{args[:index]}" if index.blank?
 
@@ -129,8 +131,10 @@ namespace :gobierto_budgets do
         year = m[0].to_i
       end
 
-      import_total_budget(year, index, 'G')
-      import_total_budget(year, index, 'I')
+      opts = args.to_h.slice(:place_type)
+
+      import_total_budget(year, index, 'G', **opts)
+      import_total_budget(year, index, 'I', **opts)
     end
   end
 end

--- a/lib/tasks/gobierto_budgets/total-budget-import.rake
+++ b/lib/tasks/gobierto_budgets/total-budget-import.rake
@@ -39,10 +39,11 @@ namespace :gobierto_budgets do
             filter: {
               bool: {
                 must: [
-                  {term: { ine_code: place.id }},
+                  {term: { ine_code: place.attributes["place_id"] }},
                   {term: { level: 1 }},
                   {term: { kind: kind }},
                   {term: { year: year }},
+                  {term: { organization_id: place.id.to_s }},
                   {missing: { field: 'functional_code'}},
                   {missing: { field: 'custom_code'}}
                 ]


### PR DESCRIPTION
This PR:

* Extracts some logic related with places used to load data in elasticsearch to a decorator:
  * The class defines 2 collections of decorated places, the INE::Places::Place full list used previously and a new `deputation_eu` collection with Euskadi foral deputatios
  * The decorator provides some methods with attributes used to generate budget lines and code to search related data in the database
* Adds a new environment variable check `ENV["custom_place_id"]` which allows an implementation to select the places to import in the same way as is done setting a `ENV["place_id"]`, `ENV["province_id"]` or `ENV["autonomous_region_id"]`. The decorated deputation_eu collection provides a "deputation_eu" custom_place_id value for each member.
* Adds a check to detect which columns of each table contain the amount data to be used in the budget lines generation.
* Adds an optional parameter at the end of budgets load tasks to load the data of different collections provided by the decorator. By default if the parameter is blank the collection used is the INE::Places::Place full list as usual

Examples of syntax using the `deputation_eu` collection:

Budgets import (take into account that there was an optional `destination_year` parameter in the old task and that is the reason to use double comma before deputation_eu):
```bash
bin/rake gobierto_budgets:budgets:import['budgets-planned','budgets-forecast-v3','economic',2023,,'deputation_eu']
```

Total budgets import:
```bash
bin/rake gobierto_budgets:total_budget:import['budgets-forecast-v3',2023,'deputation_eu']
```