### PR TITLE
Missing data improvements

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/ui.js
+++ b/app/assets/javascripts/gobierto_budgets/ui.js
@@ -327,7 +327,7 @@ $(document).on('turbolinks:load', function() {
 
   if($('#expense-treemap').length > 0){
     window.expenseTreemap = new TreemapVis('#expense-treemap', 'big', true);
-    var dataUrl = $('#expense-treemap').data(`${$('#expense-treemap').data('available-area-name')}-url`);
+    var dataUrl = $('#expense-treemap').data($('#expense-treemap').data('available-area-name') + '-url');
     window.expenseTreemap.render(dataUrl);
   }
 

--- a/app/assets/javascripts/gobierto_budgets/ui.js
+++ b/app/assets/javascripts/gobierto_budgets/ui.js
@@ -481,7 +481,8 @@ $(document).on('turbolinks:load', function() {
                 window.incomeTreemap.render($('#income-treemap').data('economic-url'));
               }
               else {
-                window.expenseTreemap.render($('#expense-treemap').data('functional-url'));
+                var dataUrl = $('#expense-treemap').data($('#expense-treemap').data('available-area-name') + '-url');
+                window.expenseTreemap.render(dataUrl);
               }
             }});
         }

--- a/app/assets/javascripts/gobierto_budgets/ui.js
+++ b/app/assets/javascripts/gobierto_budgets/ui.js
@@ -327,7 +327,8 @@ $(document).on('turbolinks:load', function() {
 
   if($('#expense-treemap').length > 0){
     window.expenseTreemap = new TreemapVis('#expense-treemap', 'big', true);
-    window.expenseTreemap.render($('#expense-treemap').data('functional-url'));
+    var dataUrl = $('#expense-treemap').data(`${$('#expense-treemap').data('available-area-name')}-url`);
+    window.expenseTreemap.render(dataUrl);
   }
 
   var hash = window.location.hash.slice(1);

--- a/app/assets/javascripts/gobierto_budgets/visSlider.js
+++ b/app/assets/javascripts/gobierto_budgets/visSlider.js
@@ -10,11 +10,14 @@ var VisSlider = Class.extend({
     // var slideYear = currentYear;
     var maxYear = parseInt(d3.select('body').attr('data-max-year'));
     var years = [];
-    d3.keys(this.data[0].values).forEach(function(year) {
-      year = parseInt(year);
-      if (year <= maxYear)
-        years.push(year);
+    this.data.forEach(function(item) {
+      d3.keys(item.values).forEach(function(year) {
+        year = parseInt(year);
+        if (year <= maxYear && !years.includes(year))
+          years.push(year);
+      })
     });
+    years = years.sort(d3.ascending);
     // var parseYear = d3.timeParse('%Y');
     // var formatYear = d3.timeFormat('%Y');
 

--- a/app/assets/javascripts/gobierto_budgets/vis_bubbles.js
+++ b/app/assets/javascripts/gobierto_budgets/vis_bubbles.js
@@ -111,6 +111,14 @@ var VisBubbles = Class.extend({
 
     return this.nodes;
   },
+  setLink: function(d) {
+    var currentPath = window.location.pathname;
+    var pathSegment = currentPath.match(/places.*\/\d{4}/)[0];
+    var placeSlug = pathSegment.replace("places/", "").replace(/\/\d{4}/, "");
+    var areaName = d.area_name || this.budget_category === 'income' ? 'economic' : 'functional';
+    var budgetCategory = this.budget_category === 'income' ? 'I' : 'G';
+    return '/budget_lines/' + placeSlug + '/' + d.year + '/' + d.id  + '/' + budgetCategory + '/' + areaName;
+  },
   update: function(year) {
     var t = d3.transition()
       .duration(500);
@@ -125,6 +133,9 @@ var VisBubbles = Class.extend({
       .attr('r', function (d) { return d.radius; })
       .attr('fill', function(d) { return this.budgetColor(d.pct_diff)}.bind(this))
 
+    d3.selectAll('.bubble-g a')
+      .attr('xlink:href', function(d) { return this.setLink(d); }.bind(this))
+
     d3.selectAll('.bubble-g text')
       .data(this.nodes, function (d) { return d.name; })
       .transition(t)
@@ -134,6 +145,7 @@ var VisBubbles = Class.extend({
     this.simulation.nodes(this.nodes)
     this.simulation.alpha(1).restart();
   },
+
   updateRender: function() {
 
     // var budgetCategory = this.budget_category;
@@ -146,14 +158,7 @@ var VisBubbles = Class.extend({
       .attr('class', 'bubble-g');
 
     var bubblesG = this.bubbles.append('a')
-      .attr('xlink:href', function(d) {
-        var currentPath = window.location.pathname;
-        var pathSegment = currentPath.match(/places.*\/\d{4}/)[0];
-        var placeSlug = pathSegment.replace("places/", "").replace(/\/\d{4}/, "");
-        var areaName = d.area_name || this.budget_category === 'income' ? 'economic' : 'functional';
-        var budgetCategory = this.budget_category === 'income' ? 'I' : 'G';
-        return '/budget_lines/' + placeSlug + '/' + d.year + '/' + d.id  + '/' + budgetCategory + '/' + areaName;
-      }.bind(this))
+      .attr('xlink:href', function(d) { return this.setLink(d); }.bind(this))
       .attr('target', '_top')
       .append('circle')
       .attr('class', function(d) { return d.year + ' bubble'})

--- a/app/assets/javascripts/gobierto_budgets/vis_bubbles.js
+++ b/app/assets/javascripts/gobierto_budgets/vis_bubbles.js
@@ -115,7 +115,7 @@ var VisBubbles = Class.extend({
     var currentPath = window.location.pathname;
     var pathSegment = currentPath.match(/places.*\/\d{4}/)[0];
     var placeSlug = pathSegment.replace("places/", "").replace(/\/\d{4}/, "");
-    var areaName = d.area_name || this.budget_category === 'income' ? 'economic' : 'functional';
+    var areaName = d.area_name || (this.budget_category === 'income' ? 'economic' : 'functional');
     var budgetCategory = this.budget_category === 'income' ? 'I' : 'G';
     return '/budget_lines/' + placeSlug + '/' + d.year + '/' + d.id  + '/' + budgetCategory + '/' + areaName;
   },

--- a/app/assets/javascripts/gobierto_budgets/vis_bubbles.js
+++ b/app/assets/javascripts/gobierto_budgets/vis_bubbles.js
@@ -84,6 +84,7 @@ var VisBubbles = Class.extend({
           values: d.values,
           pct_diffs: d.pct_diff,
           id: d.id,
+          area_name: d.area_name,
           values_per_inhabitant: d.values_per_inhabitant,
           radius: d.values[year] ? this.radiusScale(d.values[year]) : 0,
           value: d.values[year],
@@ -149,7 +150,9 @@ var VisBubbles = Class.extend({
         var currentPath = window.location.pathname;
         var pathSegment = currentPath.match(/places.*\/\d{4}/)[0];
         var placeSlug = pathSegment.replace("places/", "").replace(/\/\d{4}/, "");
-        return this.budget_category === 'income' ? '/budget_lines/' + placeSlug + '/' + d.year + '/' + d.id  + '/I/economic' : '/budget_lines/' + placeSlug  + '/' + d.year + '/' + d.id + '/G/functional';
+        var areaName = d.area_name || this.budget_category === 'income' ? 'economic' : 'functional';
+        var budgetCategory = this.budget_category === 'income' ? 'I' : 'G';
+        return '/budget_lines/' + placeSlug + '/' + d.year + '/' + d.id  + '/' + budgetCategory + '/' + areaName;
       }.bind(this))
       .attr('target', '_top')
       .append('circle')

--- a/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
+++ b/app/controllers/gobierto_budgets/featured_budget_lines_controller.rb
@@ -39,7 +39,7 @@ module GobiertoBudgets
 
       begin
         retries ||= 0
-        load_featured_budget_line(allow_year_fallback: true)
+        load_featured_budget_line
 
         if featured_budget_line?
           @amount_per_inhabitant_summary = budget_per_inhabitant_summary(default_budget_line_params)

--- a/app/controllers/gobierto_budgets/places_controller.rb
+++ b/app/controllers/gobierto_budgets/places_controller.rb
@@ -19,24 +19,7 @@ module GobiertoBudgets
       if @year.nil?
         redirect_to gobierto_budgets_place_path(current_organization.combined_slug, SearchEngineConfiguration::Year.last) and return
       end
-      load_featured_budget_line(allow_year_fallback: true)
-
-      @income_lines = BudgetLine.search(
-        organization_id: current_organization.id,
-        level: 1,
-        year: @year,
-        kind: BudgetLine::INCOME,
-        type: GobiertoBudgets::BudgetLine::ECONOMIC
-      )
-
-      @expense_lines = GobiertoBudgets::BudgetLine::AREA_NAMES.each_with_object({}) do |type, data|
-        data[type] = GobiertoBudgets::BudgetLine.search(organization_id: current_organization.id, level: 1, year: @year, kind: BudgetLine::EXPENSE, type:, recalculate_aggregations: true)
-      end
-
-      @area_names_with_expense_data = @expense_lines.select  { |_name, data| data["hits"].present? }.keys
-      @expense_area_name = @area_names_with_expense_data.include?(@area_name) ? @area_name : @area_names_with_expense_data.first
-
-      @no_data = @income_lines['hits'].empty?
+      load_budget_lines(allow_year_fallback: true)
 
       if featured_budget_line?
         @amount_per_inhabitant_summary = budget_per_inhabitant_summary(default_budget_line_params)

--- a/app/controllers/gobierto_budgets/places_controller.rb
+++ b/app/controllers/gobierto_budgets/places_controller.rb
@@ -19,6 +19,7 @@ module GobiertoBudgets
       if @year.nil?
         redirect_to gobierto_budgets_place_path(current_organization.combined_slug, SearchEngineConfiguration::Year.last) and return
       end
+      load_featured_budget_line(allow_year_fallback: true)
 
       @income_lines = BudgetLine.search(
         organization_id: current_organization.id,
@@ -30,8 +31,6 @@ module GobiertoBudgets
 
       @expense_lines = BudgetLine.search(organization_id: current_organization.id, level: 1, year: @year, kind: BudgetLine::EXPENSE, type: @area_name, recalculate_aggregations: true)
       @no_data = @income_lines['hits'].empty?
-
-      load_featured_budget_line(allow_year_fallback: true)
 
       if featured_budget_line?
         @amount_per_inhabitant_summary = budget_per_inhabitant_summary(default_budget_line_params)

--- a/app/controllers/gobierto_budgets/places_controller.rb
+++ b/app/controllers/gobierto_budgets/places_controller.rb
@@ -29,7 +29,13 @@ module GobiertoBudgets
         type: GobiertoBudgets::BudgetLine::ECONOMIC
       )
 
-      @expense_lines = BudgetLine.search(organization_id: current_organization.id, level: 1, year: @year, kind: BudgetLine::EXPENSE, type: @area_name, recalculate_aggregations: true)
+      @expense_lines = GobiertoBudgets::BudgetLine::AREA_NAMES.each_with_object({}) do |type, data|
+        data[type] = GobiertoBudgets::BudgetLine.search(organization_id: current_organization.id, level: 1, year: @year, kind: BudgetLine::EXPENSE, type:, recalculate_aggregations: true)
+      end
+
+      @area_names_with_expense_data = @expense_lines.select  { |_name, data| data["hits"].present? }.keys
+      @expense_area_name = @area_names_with_expense_data.include?(@area_name) ? @area_name : @area_names_with_expense_data.first
+
       @no_data = @income_lines['hits'].empty?
 
       if featured_budget_line?

--- a/app/controllers/gobierto_budgets/places_controller.rb
+++ b/app/controllers/gobierto_budgets/places_controller.rb
@@ -19,7 +19,7 @@ module GobiertoBudgets
       if @year.nil?
         redirect_to gobierto_budgets_place_path(current_organization.combined_slug, SearchEngineConfiguration::Year.last) and return
       end
-      load_budget_lines(allow_year_fallback: true)
+      load_budget_lines(allow_year_fallback: true, start_year: @year)
 
       if featured_budget_line?
         @amount_per_inhabitant_summary = budget_per_inhabitant_summary(default_budget_line_params)

--- a/app/helpers/gobierto_budgets/budget_line_widget_helper.rb
+++ b/app/helpers/gobierto_budgets/budget_line_widget_helper.rb
@@ -22,8 +22,11 @@ module GobiertoBudgets
           @year -= 1
           calculate_lines
         end
-      end
 
+        if params[:start_year].present? && params[:start_year] != @year
+          redirect_to gobierto_budgets_place_path(current_organization.combined_slug, @year) and return
+        end
+      end
       load_featured_budget_line
     end
 

--- a/app/models/gobierto_budgets/budget_line.rb
+++ b/app/models/gobierto_budgets/budget_line.rb
@@ -7,6 +7,7 @@ module GobiertoBudgets
     EXPENSE = 'G'
     ECONOMIC = 'economic'
     FUNCTIONAL = 'functional'
+    AREA_NAMES = [ECONOMIC, FUNCTIONAL].freeze
 
     @sort_attribute ||= 'code'
     @sort_order ||= 'asc'

--- a/app/views/gobierto_budgets/places/_expense_lines.html.erb
+++ b/app/views/gobierto_budgets/places/_expense_lines.html.erb
@@ -10,6 +10,6 @@
   <th class="bar_cont"></th>
 </tr>
 <%= render partial: 'gobierto_budgets/places/budget_lines',
-           collection: @expense_lines['hits'],
+           collection: @expense_lines[area_name]['hits'],
            as: 'budget_line',
-           locals: { total_budget: @expense_lines['aggregations']['total_budget']['value'], kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: area_name } %>
+           locals: { total_budget: @expense_lines[area_name]['aggregations']['total_budget']['value'], kind: GobiertoBudgets::BudgetLine::EXPENSE, area_name: area_name } %>

--- a/app/views/gobierto_budgets/places/show.html.erb
+++ b/app/views/gobierto_budgets/places/show.html.erb
@@ -68,25 +68,31 @@
 
       <div class="form_filters">
         <ul>
-          <li><%= link_to t('common.economic').capitalize, gobierto_budgets_place_path(current_organization.combined_slug, @year, {area: 'economic'}), remote: true, class: 'toggle', id: 'Economica' %></li>
-          <li><%= link_to t('common.functional').capitalize, gobierto_budgets_place_path(current_organization.combined_slug, @year, {area: 'functional'}), remote: true, class: 'toggle buttonSelected', id: 'Funcional' %></li>
+          <% @area_names_with_expense_data.each do |area_name| %>
+            <li><%= link_to t(area_name, scope: "common").capitalize, gobierto_budgets_place_path(current_organization.combined_slug, @year, { area: area_name }), remote: true, class: "toggle #{"buttonSelected" if area_name == @expense_area_name}", id: area_name.capitalize %></li>
+          <% end %>
         </ul>
       </div>
 
-      <div id="total_expense_budget" class="qty"><%= number_to_currency @expense_lines['aggregations']['total_budget']['value'], precision: 0 %></div>
+      <% if @expense_area_name.present? %>
+        <div id="total_expense_budget" class="qty"><%= number_to_currency @expense_lines[@expense_area_name]['aggregations']['total_budget']['value'], precision: 0 %></div>
+      <% end %>
     </header>
 
-    <div class="graph" id="expense-treemap"
-                       data-functional-url="<%= gobierto_budgets_place_budget_path(current_organization.combined_slug, @year, GobiertoBudgets::BudgetLine::EXPENSE, 'functional', nil, format: :json) %>"
-                       data-economic-url="<%= gobierto_budgets_place_budget_path(current_organization.combined_slug, @year, GobiertoBudgets::BudgetLine::EXPENSE, 'economic', nil, format: :json) %>">
-    </div>
+    <% if @expense_area_name.present? %>
+      <div class="graph" id="expense-treemap"
+                         data-available-area-name="<%= @expense_area_name %>"
+                         data-functional-url="<%= gobierto_budgets_place_budget_path(current_organization.combined_slug, @year, GobiertoBudgets::BudgetLine::EXPENSE, 'functional', nil, format: :json) %>"
+                         data-economic-url="<%= gobierto_budgets_place_budget_path(current_organization.combined_slug, @year, GobiertoBudgets::BudgetLine::EXPENSE, 'economic', nil, format: :json) %>">
+      </div>
 
-    <div class="items">
-      <table id="expense_lines">
-        <%= render partial: 'gobierto_budgets/places/expense_lines', locals: { area_name: @area_name } %>
-      </table>
+      <div class="items">
+        <table id="expense_lines">
+          <%= render partial: 'gobierto_budgets/places/expense_lines', locals: { area_name: @expense_area_name } %>
+        </table>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <div class="cont-income hidden">
     <header class="cat incomes">

--- a/app/views/gobierto_budgets/places/show.js.erb
+++ b/app/views/gobierto_budgets/places/show.js.erb
@@ -1,5 +1,5 @@
 $('.toggle').toggleClass('buttonSelected');
-$('#total_expense_budget').text("<%= number_to_currency @expense_lines['aggregations']['total_budget']['value'], precision: 0 %>")
+$('#total_expense_budget').text("<%= number_to_currency @expense_lines[@area_name]['aggregations']['total_budget']['value'], precision: 0 %>")
 $('#expense_lines').html("<%= j render(partial: 'gobierto_budgets/places/expense_lines', locals: { area_name: @area_name }) %>");
 
 $('#show_expenses_link').replaceWith("<%= j link_to 'Ver desglose de gastos',


### PR DESCRIPTION
Fixes PopulateTools/issues#1889

This PR:
* Changes data calculation in places controller show action to generate data of year updated in the controller to find a year with data
* Adds to the same action a request of expense data to check availability of existing data for functional and economic categories and hides the tab with missing data and changes the default expense data to be shown