### PR TITLE
Allow combining municipalities and deputations in searches

### DIFF
--- a/app/assets/javascripts/gobierto_budgets/ui.js
+++ b/app/assets/javascripts/gobierto_budgets/ui.js
@@ -22,6 +22,8 @@ $(document).on('turbolinks:load', function() {
   var placesFile = window.placesFile || '/places.json';
   var placesType = window.placesType || 'Place';
   var placesPath = window.placesPath || '/municipios';
+  var entitiesPath = window.entitiesPath || { "Place": "/municipios", "Deputation": "/diputaciones" };
+  var combinePlacesCollectionsInSearches = window.combinePlacesCollectionsInSearches || false;
 
   // Modals
   $('.open_modal').magnificPopup({
@@ -53,11 +55,11 @@ $(document).on('turbolinks:load', function() {
       $.ajax(placesFile, {
         complete: function(data) {
           var suggestions = data.responseJSON.filter(function(result){
-          return result.data.type == placesType && (
-            result.value.indexOf(query) !== -1 ||
-            result.data.slug.indexOf(query) !== -1 ||
-            result.value.toLowerCase().indexOf(query) !== -1
-          )
+            return (combinePlacesCollectionsInSearches || result.data.type == placesType) && (
+              result.value.indexOf(query) !== -1 ||
+              result.data.slug.indexOf(query) !== -1 ||
+              result.value.toLowerCase().indexOf(query) !== -1
+            )
           });
           var result = {
             suggestions: suggestions
@@ -67,12 +69,13 @@ $(document).on('turbolinks:load', function() {
       })
     },
     onSelect: function(suggestion) {
-      if(suggestion.data.type == placesType) {
+      var entityPath = entitiesPath[suggestion.data.type]
+      if(entityPath) {
         ga('send', 'event', 'Place Search', 'Click', 'Search', {nonInteraction: true});
         if(mixpanel.length > 0) {
           mixpanel.track('Place Search', { 'Place': suggestion.data.slug});
         }
-        window.location.href = placesPath + '/' + suggestion.data.slug;
+        window.location.href = entityPath + '/' + suggestion.data.slug;
       }
     },
     groupBy: 'category'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::UnknownFormat, with: :render_404
   rescue_from Elasticsearch::Transport::Transport::Errors::BadRequest, with: :render_404
 
-  helper_method :helpers, :users_enabled?, :places_collection_key, :location_root_path
+  helper_method :helpers, :users_enabled?, :places_collection_key, :location_root_path, :places_collections_root_paths
 
   before_action :set_locale, :set_cache_headers
 
@@ -81,8 +81,14 @@ class ApplicationController < ActionController::Base
                                end
   end
 
-  def location_root_path
-    if places_collection_key == :deputation_eu
+  def places_collections_root_paths
+    PlaceDecorator.places_keys.each_with_object({}) do |key, paths|
+      paths[PlaceDecorator.place_type(key)] = location_root_path(key)
+    end
+  end
+
+  def location_root_path(key = places_collection_key)
+    if key == :deputation_eu
       deputation_root_path
     else
       place_root_path

--- a/app/views/layouts/gobierto_budgets_application.html.erb
+++ b/app/views/layouts/gobierto_budgets_application.html.erb
@@ -43,6 +43,8 @@
     window.placesFile = "<%= Settings.places_file || "/places.json" %>";
     window.placesType = "<%= PlaceDecorator.place_type(places_collection_key) %>";
     window.placesPath = "<%= location_root_path %>";
+    window.entitiesPath = <%== places_collections_root_paths.to_json %>;
+    window.combinePlacesCollectionsInSearches = <%= Settings.combine_places_collections_in_searches || false %>;
   </script>
 </head>
 

--- a/app/views/layouts/gobierto_budgets_embedded.html.erb
+++ b/app/views/layouts/gobierto_budgets_embedded.html.erb
@@ -29,6 +29,8 @@
   window.placesFile = "<%= Settings.places_file || "/places.json" %>"
   window.placesType = "<%= PlaceDecorator.place_type(places_collection_key) %>"
   window.placesPath = "<%= location_root_path %>"
+  window.entitiesPath = <%= places_collections_root_paths.to_json %>
+  window.combinePlacesCollectionsInSearches = <%= Settings.combine_places_collections_in_searches || false %>
   $(function () {
     <%= yield :javascript %>
   });

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -11,6 +11,7 @@ map_zoom_level: 6
 map_topojson: '/municipalities_topojson.json'
 twitter_account: '@gobierto'
 places_file: '/places_with_deputations.json'
+combine_places_collections_in_searches: false
 search_examples:
   ine:
     - "santander"


### PR DESCRIPTION
This PR:
* Adds to the settings file a `combine_places_collections_in_searches` parameter which when enabled allows searches box to combine municipalities and deputations redirecting to the correct path depending on the entity type. This parameter is false by default

The feature can be checked in euskadi: https://ogp-euskadi.gobify.net/municipios allowing users to search by both municipalities and deputations in the same page

This PR fixes PopulateTools/issues#1953